### PR TITLE
Fixes for PR

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -42,7 +42,7 @@ timestamp='2021-06-03'
 # have a pre-POSIX /bin/sh.
 
 
-me=$(echo "$0" | sed -e 's,.*/,,')
+me=`echo "$0" | sed -e 's,.*/,,'`
 
 usage="\
 Usage: $0 [OPTION]
@@ -318,7 +318,7 @@ case $UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION in
 	trap '' 0
 	case $UNAME_RELEASE in
 	*4.0)
-		UNAME_RELEASE=$(/usr/sbin/sizer -v | awk '{print $3}')
+		UNAME_RELEASE=`/usr/sbin/sizer -v | awk '{print $3}'`
 		;;
 	*5.*)
 		UNAME_RELEASE=`/usr/sbin/sizer -v | awk '{print $4}'`
@@ -456,7 +456,7 @@ case $UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION in
     sun4*:SunOS:*:*)
 	case `/usr/bin/arch -k` in
 	    Series*|S4*)
-		UNAME_RELEASE=$(uname -v)
+		UNAME_RELEASE=`uname -v`
 		;;
 	esac
 	# Japanese Language versions have a version number like `4.1.3-JL'.
@@ -1218,7 +1218,7 @@ EOF
 		UNAME_REL=`sed -n 's/.*Version //p' </usr/options/cb.name`
 		GUESS=$UNAME_MACHINE-pc-isc$UNAME_REL
 	elif /bin/uname -X 2>/dev/null >/dev/null ; then
-		UNAME_REL=$( (/bin/uname -X|grep Release|sed -e 's/.*= //'))
+		UNAME_REL=`(/bin/uname -X|grep Release|sed -e 's/.*= //')`
 		(/bin/uname -X|grep i80486 >/dev/null) && UNAME_MACHINE=i486
 		(/bin/uname -X|grep '^Machine.*Pentium' >/dev/null) \
 			&& UNAME_MACHINE=i586
@@ -1268,7 +1268,7 @@ EOF
     3[345]??:*:4.0:3.0 | 3[34]??A:*:4.0:3.0 | 3[34]??,*:*:4.0:3.0 | 3[34]??/*:*:4.0:3.0 | 4400:*:4.0:3.0 | 4850:*:4.0:3.0 | SKA40:*:4.0:3.0 | SDS2:*:4.0:3.0 | SHG2:*:4.0:3.0 | S7501*:*:4.0:3.0)
 	OS_REL=''
 	test -r /etc/.relid \
-	&& OS_REL=.$(sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid)
+	&& OS_REL=.`sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid`
 	/bin/uname -p 2>/dev/null | grep 86 >/dev/null \
 	  && { echo i486-ncr-sysv4.3"$OS_REL"; exit; }
 	/bin/uname -p 2>/dev/null | /bin/grep entium >/dev/null \
@@ -1581,7 +1581,7 @@ main ()
 #define __ARCHITECTURE__ "m68k"
 #endif
   int version;
-  version=$( (hostinfo | sed -n 's/.*NeXT Mach \([0-9]*\).*/\1/p') 2>/dev/null);
+  version=`(hostinfo | sed -n 's/.*NeXT Mach \([0-9]*\).*/\1/p') 2>/dev/null`;
   if (version < 4)
     printf ("%s-next-nextstep%d\n", __ARCHITECTURE__, version);
   else
@@ -1716,20 +1716,20 @@ provide the necessary information to handle your system.
 
 config.guess timestamp = $timestamp
 
-uname -m = $( (uname -m) 2>/dev/null || echo unknown)
-uname -r = $( (uname -r) 2>/dev/null || echo unknown)
-uname -s = $( (uname -s) 2>/dev/null || echo unknown)
-uname -v = $( (uname -v) 2>/dev/null || echo unknown)
+uname -m = `(uname -m) 2>/dev/null || echo unknown`
+uname -r = `(uname -r) 2>/dev/null || echo unknown`
+uname -s = `(uname -s) 2>/dev/null || echo unknown`
+uname -v = `(uname -v) 2>/dev/null || echo unknown`
 
-/usr/bin/uname -p = $( (/usr/bin/uname -p) 2>/dev/null)
-/bin/uname -X     = $( (/bin/uname -X) 2>/dev/null)
+/usr/bin/uname -p = `(/usr/bin/uname -p) 2>/dev/null`
+/bin/uname -X     = `(/bin/uname -X) 2>/dev/null`
 
-hostinfo               = $( (hostinfo) 2>/dev/null)
-/bin/universe          = $( (/bin/universe) 2>/dev/null)
-/usr/bin/arch -k       = $( (/usr/bin/arch -k) 2>/dev/null)
-/bin/arch              = $( (/bin/arch) 2>/dev/null)
-/usr/bin/oslevel       = $( (/usr/bin/oslevel) 2>/dev/null)
-/usr/convex/getsysinfo = $( (/usr/convex/getsysinfo) 2>/dev/null)
+hostinfo               = `(hostinfo) 2>/dev/null`
+/bin/universe          = `(/bin/universe) 2>/dev/null`
+/usr/bin/arch -k       = `(/usr/bin/arch -k) 2>/dev/null`
+/bin/arch              = `(/bin/arch) 2>/dev/null`
+/usr/bin/oslevel       = `(/usr/bin/oslevel) 2>/dev/null`
+/usr/convex/getsysinfo = `(/usr/convex/getsysinfo) 2>/dev/null`
 
 UNAME_MACHINE = "$UNAME_MACHINE"
 UNAME_RELEASE = "$UNAME_RELEASE"
@@ -1746,3 +1746,4 @@ exit 1
 # time-stamp-format: "%:y-%02m-%02d"
 # time-stamp-end: "'"
 # End:
+

--- a/src/elfcore.c
+++ b/src/elfcore.c
@@ -1829,12 +1829,10 @@ int InternalGetCoreDump(void *frame, int num_threads, pid_t *pids,
   /* Get parent's CPU registers, and user data structure                     */
   {
     #ifndef __mips__
-    #ifndef __aarch64__ // PTRACE_PEEKUSER returns -1 and set errno = 5 (EIO 5 Input/output error)
     for (i = 0; i < sizeof(struct core_user); i += sizeof(int)) {
       sys_ptrace(PTRACE_PEEKUSER, pids[0], (void *)i,
                  ((char *)&user) + i);
     }
-    #endif
 
     /* Overwrite the regs from ptrace with the ones previously computed.  */
     memcpy(&user.regs, thread_regs, sizeof(struct regs));

--- a/src/elfcore.c
+++ b/src/elfcore.c
@@ -1847,9 +1847,7 @@ int InternalGetCoreDump(void *frame, int num_threads, pid_t *pids,
   prpsinfo.pr_gid   = sys_getegid();
   prpsinfo.pr_pid   = main_pid;
   prpsinfo.pr_ppid  = sys_getppid();
-  #if !defined(__aarch64__)
-  prpsinfo.pr_pgrp  = sys_getpgrp();
-  #endif
+  prpsinfo.pr_pgrp  = getpgrp();
   prpsinfo.pr_sid   = sys_getsid(0);
   /* scope */ {
     char scratch[4096], *cmd = scratch, *ptr;

--- a/src/elfcore.c
+++ b/src/elfcore.c
@@ -48,6 +48,7 @@ extern "C" {
 #include <string.h>
 #include <sys/poll.h>
 #include <sys/prctl.h>
+#include <sys/procfs.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
@@ -73,10 +74,10 @@ extern "C" {
     #define O_LARGEFILE 0x2000
   #elif defined(__ARM_ARCH_3__)
     #define O_LARGEFILE 0400000
-  #elif defined(__aarch64__)
-    #define O_LARGEFILE  __O_LARGEFILE
   #elif defined(__PPC__) || defined(__ppc__)
     #define O_LARGEFILE 0200000
+  #elif defined(__O_LARGEFILE)
+    #define O_LARGEFILE  __O_LARGEFILE
   #else
     #define O_LARGEFILE 00100000 /* generic                                  */
   #endif
@@ -168,15 +169,7 @@ typedef struct elf_timeval {    /* Time value with microsecond resolution    */
   long tv_usec;                 /* Microseconds                              */
 } elf_timeval;
 
-#if !defined(__aarch64__)
-typedef struct elf_siginfo {    /* Information about signal (unused)         */
-  int32_t si_signo;             /* Signal number                             */
-  int32_t si_code;              /* Extra code                                */
-  int32_t si_errno;             /* Errno                                     */
-} elf_siginfo;
-#else
 typedef struct elf_siginfo elf_siginfo;
-#endif
 
 typedef struct prstatus {       /* Information about thread; includes CPU reg*/
   elf_siginfo    pr_info;       /* Info associated with signal               */

--- a/src/linuxthreads.c
+++ b/src/linuxthreads.c
@@ -624,16 +624,10 @@ int ListAllProcessThreads(void *parameter,
 
     if (clone_pid >= 0) {
       int status, rc;
-      #if defined (__aarch64__)
-      while ((rc = sys_waitpid(clone_pid, &status, __WALL)) < 0 && ERRNO == EINTR) {
-             /* Keep waiting                                                 */
-      }
-      #else
       while ((rc = sys0_waitpid(clone_pid, &status, __WALL)) < 0 &&
              ERRNO == EINTR) {
              /* Keep waiting                                                 */
       }
-      #endif
       if (rc < 0) {
         args.err = ERRNO;
         args.result = -1;


### PR DESCRIPTION
- replace config.guess with the one from the official GNU repo
- use __O_LARGEFILE if it is defined. 
- use struct elf_siginfo from procfs.h on all platforms
- simplified if statements in the reading of the registers for arm64
- use getpgrp() instead of sys_getpgrp() which is deprecated on arm64
- reverted PTRACE_PEEKUSER and sys0_waitpid. Both works fine on arm64-linux.